### PR TITLE
Add underdamped bosonic spectral density

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -52,6 +52,7 @@ const PAGES = Any[
         "Bosonic Bath"=>Any[
             "Introduction"=>"bath_boson/bosonic_bath_intro.md",
             "Drude-Lorentz Spectral Density"=>"bath_boson/Boson_Drude_Lorentz.md",
+            "Underdamped Spectral Density"=>"bath_boson/Boson_Underdamped.md",
         ],
         "Bosonic Bath (RWA)"=>Any["Introduction"=>"bath_boson_RWA/bosonic_bath_RWA_intro.md"],
         "Fermionic Bath"=>Any[

--- a/docs/src/bath_boson/Boson_Underdamped.md
+++ b/docs/src/bath_boson/Boson_Underdamped.md
@@ -1,0 +1,37 @@
+# [Underdamped Spectral Density](@id Boson-Underdamped)
+```math
+J(\omega)=\frac{\lambda^2 \Gamma \omega}{(\omega^2 - \omega_0^2)^2 + \omega^2\Gamma^2}
+```
+Here, ``\lambda`` represents the coupling strength between system and the bosonic environment with band-width ``\Gamma`` and resonance frequency ``\omega_0``.
+
+## Matsubara Expansion
+With Matsubara Expansion, the correlation function can be analytically solved and expressed as follows:
+```math
+C(t_1, t_2) = C^\mathrm{R}(t_1, t_2) + iC^\mathrm{I}(t_1, t_2) = \sum_{l=1}^{\infty} \eta_l^\mathrm{R} \exp(-\gamma_l^\mathrm{R} (t_1-t_2)) + \sum_{l=1}^{2} \eta_l^\mathrm{I} \exp(-\gamma_l^\mathrm{I} (t_1-t_2))
+```
+with
+```math
+\begin{aligned}
+\gamma_{1}^\mathrm{R} &= -i\Omega + \frac{\Gamma}{2},\\
+\eta_{1}^\mathrm{R} &= \frac{\lambda^2}{4\Omega}\coth\left[\frac{1}{2 k_B T}\left(\Omega + i\frac{\Gamma}{2}\right)\right],\\
+\gamma_{2}^\mathrm{R} &= i\Omega + \frac{\Gamma}{2},\\
+\eta_{2}^\mathrm{R} &= \frac{\lambda^2}{4\Omega}\coth\left[\frac{1}{2 k_B T}\left(\Omega - i\frac{\Gamma}{2}\right)\right],\\
+\gamma_{l\neq 2}^\mathrm{R} &= 2\pi l k_B T,\\
+\eta_{l\neq 2}^\mathrm{R} &= -2 k_B T \cdot \frac{\lambda^2 \Gamma \cdot \gamma_l^\mathrm{R}}{\left[\left(\Omega + i\frac{\Gamma}{2}\right)^2 + {\gamma_l^\mathrm{R}}^2\right]\left[\left(\Omega - i\frac{\Gamma}{2}\right)^2 + {\gamma_l^\mathrm{R}}^2\right]},\\
+\gamma_{1}^\mathrm{I} &= i\Omega + \frac{\Gamma}{2},\\
+\eta_{1}^\mathrm{I} &= i\frac{\lambda^2}{4\Omega},\\
+\gamma_{2}^\mathrm{I} &= -i\Omega + \frac{\Gamma}{2},\\
+\eta_{2}^\mathrm{I} &= -i\frac{\lambda^2}{4\Omega},
+\end{aligned}
+```
+where ``\Omega = \sqrt{\omega_0^2 + (\Gamma/2)^2}``.
+This can be constructed by the built-in function [`Boson_Underdamped_Matsubara`](@ref):
+```julia
+Vs # coupling operator
+λ  # coupling strength
+Γ  # band-width of the environment
+ω0 # resonance frequency of the environment
+kT # the product of the Boltzmann constant k and the absolute temperature T
+N  # Number of exponential terms
+bath = Boson_Underdamped_Matsubara(Vs, λ, Γ, ω0, kT, N - 2)
+```

--- a/docs/src/libraryAPI.md
+++ b/docs/src/libraryAPI.md
@@ -45,6 +45,7 @@ fermionEmit(op::QuantumObject, η_emit::Vector{Ti}, γ_emit::Vector{Tj}, η_abso
 ```@docs
 Boson_DrudeLorentz_Matsubara
 Boson_DrudeLorentz_Pade
+Boson_Underdamped_Matsubara
 Fermion_Lorentz_Matsubara
 Fermion_Lorentz_Pade
 ```

--- a/src/bath_correlation_functions/bath_correlation_func.jl
+++ b/src/bath_correlation_functions/bath_correlation_func.jl
@@ -2,6 +2,7 @@ include("utils.jl")
 
 # bosonic bath correlation functions
 include("boson/DrudeLorentz.jl")
+include("boson/Underdamped.jl")
 
 # fermionic bath correlation functions
 include("fermion/Lorentz.jl")

--- a/src/bath_correlation_functions/boson/Underdamped.jl
+++ b/src/bath_correlation_functions/boson/Underdamped.jl
@@ -1,0 +1,35 @@
+export Boson_Underdamped_Matsubara
+
+@doc raw"""
+    Boson_Underdamped_Matsubara(op, λ, Γ, ω0, kT, N)
+Construct an underdamped bosonic bath with Matsubara expansion
+
+# Parameters
+- `op` : The system coupling operator, must be Hermitian and, for fermionic systems, even-parity to be compatible with charge conservation.
+- `λ::Real`: The coupling strength between the system and the bath.
+- `Γ::Real`: The band-width of the bath spectral density.
+- `ω0::Real`: The resonance frequency of the bath spectral density.
+- `kT::Real`: The product of the Boltzmann constant ``k`` and the absolute temperature ``T`` of the bath.
+- `N::Int`: (N+2)-terms of exponential terms are used to approximate the bath correlation function.
+
+# Returns
+- `bath::BosonBath` : a bosonic bath object with describes the interaction between system and bosonic bath
+"""
+function Boson_Underdamped_Matsubara(op, λ::Real, Γ::Real, ω0::Real, kT::Real, N::Int)
+    Ω = sqrt(ω0^2 - (Γ/2)^2)
+    ν = 2π*kT*(1:N)
+
+    η_real = ComplexF64[(λ^2/(4*Ω))*coth((Ω + im*Γ/2)/(2*kT)), (λ^2/(4*Ω))*coth((Ω - im*Γ/2)/(2*kT))]
+    γ_real = ComplexF64[Γ/2 - im*Ω, Γ/2 + im*Ω]
+    η_imag = ComplexF64[(λ^2/(4*Ω))*im, -(λ^2/(4*Ω))*im]
+    γ_imag = ComplexF64[Γ/2 - im*Ω, Γ/2 + im*Ω]
+
+    if N > 0
+        for l in 1:N
+            append!(η_real, -2*λ^2*Γ*kT*ν[l]/(((Ω + im*Γ/2)^2 + ν[l]^2)*((Ω - im*Γ/2)^2 + ν[l]^2)))
+            append!(γ_real, ν[l])
+        end
+    end
+
+    return BosonBath(op, η_real, γ_real, η_imag, γ_imag)
+end

--- a/src/bath_correlation_functions/boson/Underdamped.jl
+++ b/src/bath_correlation_functions/boson/Underdamped.jl
@@ -16,17 +16,17 @@ Construct an underdamped bosonic bath with Matsubara expansion
 - `bath::BosonBath` : a bosonic bath object with describes the interaction between system and bosonic bath
 """
 function Boson_Underdamped_Matsubara(op, λ::Real, Γ::Real, ω0::Real, kT::Real, N::Int)
-    Ω = sqrt(ω0^2 - (Γ/2)^2)
-    ν = 2π*kT*(1:N)
+    Ω = sqrt(ω0^2 - (Γ / 2)^2)
+    ν = 2π * kT * (1:N)
 
-    η_real = ComplexF64[(λ^2/(4*Ω))*coth((Ω + im*Γ/2)/(2*kT)), (λ^2/(4*Ω))*coth((Ω - im*Γ/2)/(2*kT))]
-    γ_real = ComplexF64[Γ/2 - im*Ω, Γ/2 + im*Ω]
-    η_imag = ComplexF64[(λ^2/(4*Ω))*im, -(λ^2/(4*Ω))*im]
-    γ_imag = ComplexF64[Γ/2 - im*Ω, Γ/2 + im*Ω]
+    η_real = ComplexF64[(λ^2/(4*Ω))*coth((Ω + im * Γ / 2) / (2 * kT)), (λ^2/(4*Ω))*coth((Ω - im * Γ / 2) / (2 * kT))]
+    γ_real = ComplexF64[Γ/2-im*Ω, Γ/2+im*Ω]
+    η_imag = ComplexF64[(λ^2/(4*Ω))*im, -(λ^2 / (4 * Ω))*im]
+    γ_imag = ComplexF64[Γ/2-im*Ω, Γ/2+im*Ω]
 
     if N > 0
         for l in 1:N
-            append!(η_real, -2*λ^2*Γ*kT*ν[l]/(((Ω + im*Γ/2)^2 + ν[l]^2)*((Ω - im*Γ/2)^2 + ν[l]^2)))
+            append!(η_real, -2 * λ^2 * Γ * kT * ν[l] / (((Ω + im * Γ / 2)^2 + ν[l]^2) * ((Ω - im * Γ / 2)^2 + ν[l]^2)))
             append!(γ_real, ν[l])
         end
     end

--- a/test/bath_corr_func.jl
+++ b/test/bath_corr_func.jl
@@ -50,6 +50,39 @@
         @test e.γ ≈ γ[i] atol = 1.0e-10
     end
 
+    # Boson Underdamped Matsubara
+    b = Boson_Underdamped_Matsubara(op, λ, W, μ, kT, N)
+    η = [
+        -0.00018928791202842962 + 0.0im,
+        -2.459796602810069e-5 + 0.0im,
+        -7.340987667241645e-6 + 0.0im,
+        -3.1048013140938362e-6 + 0.0im,
+        0.004830164921597723 - 0.0035513512668150157im,
+        0.017695757954237043 + 0.0035513512668150157im,
+    ]
+    γ = [
+        4.658353586742945 + 0.0im,
+        9.31670717348589 + 0.0im,
+        13.975060760228835 + 0.0im,
+        18.63341434697178 + 0.0im,
+        0.3232 - 0.8171018602353075im,
+        0.3232 + 0.8171018602353075im,
+    ]
+    types = [
+        "bR",
+        "bR",
+        "bR",
+        "bR",
+        "bRI",
+        "bRI",
+    ]
+    @test length(b) == 6
+    for (i, e) in enumerate(b)
+        @test e.η ≈ η[i] atol = 1.0e-10
+        @test e.γ ≈ γ[i] atol = 1.0e-10
+        @test e.types == types[i]
+    end
+
     # Fermion Lorentz Matsubara
     b = Fermion_Lorentz_Matsubara(op, λ, μ, W, kT, N)
     η = [

--- a/test/bath_corr_func.jl
+++ b/test/bath_corr_func.jl
@@ -68,14 +68,7 @@
         0.3232 - 0.8171018602353075im,
         0.3232 + 0.8171018602353075im,
     ]
-    types = [
-        "bR",
-        "bR",
-        "bR",
-        "bR",
-        "bRI",
-        "bRI",
-    ]
+    types = ["bR", "bR", "bR", "bR", "bRI", "bRI"]
     @test length(b) == 6
     for (i, e) in enumerate(b)
         @test e.η ≈ η[i] atol = 1.0e-10


### PR DESCRIPTION
This pr adds a convenience constructor for underdamped spectral densities frequently used in the literature.

The pr adds the new bath constructors, documentation, and tests, so I think should have all necessary features to be merged.

The implementation follows exactly the same convention as in QuTiP. I have further tested the results with those of QuTiP and they agree.

Fixes #123