### PR TITLE
Underdamped terminator

### DIFF
--- a/src/bath_correlation_functions/boson/Underdamped.jl
+++ b/src/bath_correlation_functions/boson/Underdamped.jl
@@ -34,7 +34,7 @@ function Boson_Underdamped_Matsubara(op, λ::Real, W::Real, ω0::Real, kT::Real,
         end
     end
 
-    δ = kT*W*λ^2/ω0^4 - sum(η_real./γ_real)
+    δ = kT * W * λ^2 / ω0^4 - sum(η_real ./ γ_real)
 
     return BosonBath(op, η_real, γ_real, η_imag, γ_imag, δ)
 end

--- a/src/bath_correlation_functions/boson/Underdamped.jl
+++ b/src/bath_correlation_functions/boson/Underdamped.jl
@@ -34,5 +34,7 @@ function Boson_Underdamped_Matsubara(op, λ::Real, W::Real, ω0::Real, kT::Real,
         end
     end
 
-    return BosonBath(op, η_real, γ_real, η_imag, γ_imag)
+    δ = kT*W*λ^2/ω0^4 - sum(η_real./γ_real)
+
+    return BosonBath(op, η_real, γ_real, η_imag, γ_imag, δ)
 end


### PR DESCRIPTION
The current PR is a follow up of #124 which adds the terminator for underdamped spectral densities.

I have not been able to find analytical expressions for the terminator in the literature (or other packages, QuTiP lacks it as well), so I derived it myself. I attach here the calculation for reference / cross-checking:

<img width="920" alt="derivation" src="https://github.com/user-attachments/assets/1162be1b-fba7-45a1-9de4-a1784ab25114" />

I have tested the implemented terminator for a couple of different Hamiltonians (2, 3, and 4 level systems) and a few different parameter sets and they seem to work correctly.

Here I attach an example for the case of a spin-boson model:

![underdamped_terminator_comparison](https://github.com/user-attachments/assets/3b17aff9-ed8b-45ce-b387-c92ecfa88815)
