### PR TITLE
Optimize the usage of `FunctionCallingCallback` and `TerminateSteadyState` callbacks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HierarchicalEOM"
 uuid = "a62dbcb7-80f5-4d31-9a88-8b19fd92b128"
 authors = ["Yi-Te Huang"]
-version = "2.4.4"
+version = "2.4.5"
 
 [deps]
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
@@ -35,7 +35,7 @@ LinearSolve = "2.4.2 - 3"
 OrdinaryDiffEqCore = "1"
 OrdinaryDiffEqLowOrderRK = "1"
 Pkg = "1"
-QuantumToolbox = "0.27"
+QuantumToolbox = "0.28"
 Reexport = "1"
 SciMLBase = "2"
 SciMLOperators = "0.3"

--- a/src/HierarchicalEOM.jl
+++ b/src/HierarchicalEOM.jl
@@ -16,6 +16,7 @@ import QuantumToolbox:
     _gen_dimensions,
     _get_dims_string,
     dimensions_to_dims,
+    _save_func,
     _merge_saveat,
     DEFAULT_ODE_SOLVER_OPTIONS
 
@@ -25,7 +26,7 @@ import SciMLOperators:
     AbstractSciMLOperator, MatrixOperator, ScaledOperator, AddedOperator, update_coefficients!, concretize
 import OrdinaryDiffEqCore: OrdinaryDiffEqAlgorithm
 import OrdinaryDiffEqLowOrderRK: DP5
-import DiffEqCallbacks: PresetTimeCallback, TerminateSteadyState
+import DiffEqCallbacks: FunctionCallingCallback, TerminateSteadyState
 import LinearSolve: LinearProblem, SciMLLinearSolveAlgorithm, UMFPACKFactorization
 
 # other dependencies (in alphabetical order)

--- a/src/HierarchicalEOM.jl
+++ b/src/HierarchicalEOM.jl
@@ -18,7 +18,8 @@ import QuantumToolbox:
     dimensions_to_dims,
     _save_func,
     _merge_saveat,
-    DEFAULT_ODE_SOLVER_OPTIONS
+    DEFAULT_ODE_SOLVER_OPTIONS,
+    SteadyStateODECondition
 
 # SciML packages (for OrdinaryDiffEq and LinearSolve)
 import SciMLBase: init, solve, solve!, u_modified!, ODEProblem, FullSpecialize, CallbackSet, NullParameters

--- a/src/evolution.jl
+++ b/src/evolution.jl
@@ -295,7 +295,7 @@ end
 (f::SaveFuncHEOMSolve{Nothing})(u, t, integrator) = _save_func(integrator, f.progr) # Common for both mesolve and sesolve
 
 function _save_func_heomsolve(u, integrator, tr_e_ops, progr, iter, expvals)
-    _expect = op -> dot(op, integrator.u)
+    _expect = op -> dot(op, u)
     @. expvals[:, iter[]] = _expect(tr_e_ops)
     iter[] += 1
     return _save_func(integrator, progr)

--- a/src/evolution.jl
+++ b/src/evolution.jl
@@ -16,7 +16,7 @@ A structure storing the results and some information from solving time evolution
 - `abstol::Real`: The absolute tolerance which is used during the solving process.
 - `reltol::Real`: The relative tolerance which is used during the solving process.
 """
-struct TimeEvolutionHEOMSol{TT<:Vector{<:Real},TS<:Vector{ADOs},TE<:Matrix{ComplexF64}}
+struct TimeEvolutionHEOMSol{TT<:Vector{<:Real},TS<:Vector{ADOs},TE<:Union{Nothing,Matrix{ComplexF64}}}
     Btier::Int
     Ftier::Int
     times::TT
@@ -35,7 +35,11 @@ function Base.show(io::IO, sol::TimeEvolutionHEOMSol)
     print(io, "Btier = $(sol.Btier)\n")
     print(io, "Ftier = $(sol.Ftier)\n")
     print(io, "num_ados   = $(length(sol.ados))\n")
-    print(io, "num_expect = $(size(sol.expect, 1))\n")
+    if sol.expect isa Nothing
+        print(io, "num_expect = 0\n")
+    else
+        print(io, "num_expect = $(size(sol.expect, 1))\n")
+    end
     print(io, "ODE alg.: $(sol.alg)\n")
     print(io, "abstol = $(sol.abstol)\n")
     print(io, "reltol = $(sol.reltol)\n")

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -81,11 +81,13 @@ function QuantumToolbox.steadystate(
     Tspan = (ftype(0), ftype(tspan))
 
     kwargs = merge(
-        (abstol = DEFAULT_ODE_SOLVER_OPTIONS.abstol,
-        reltol = DEFAULT_ODE_SOLVER_OPTIONS.reltol,
-        save_everystep = false,
-        saveat = ftype[]),
-        SOLVEROptions
+        (
+            abstol = DEFAULT_ODE_SOLVER_OPTIONS.abstol,
+            reltol = DEFAULT_ODE_SOLVER_OPTIONS.reltol,
+            save_everystep = false,
+            saveat = ftype[],
+        ),
+        SOLVEROptions,
     )
     _ss_condition = SteadyStateODECondition(similar(u0))
     cb = TerminateSteadyState(kwargs.abstol, kwargs.reltol, _ss_condition)

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -77,9 +77,17 @@ function QuantumToolbox.steadystate(
     _check_parity(M, ados)
     u0 = _HandleVectorType(M, ados.data)
 
-    Tspan = (0, tspan)
+    ftype = _FType(M)
+    Tspan = (ftype(0), ftype(tspan))
 
-    kwargs = merge(DEFAULT_ODE_SOLVER_OPTIONS, SOLVEROptions)
+    kwargs = merge(
+        (abstol = DEFAULT_ODE_SOLVER_OPTIONS.abstol,
+        reltol = DEFAULT_ODE_SOLVER_OPTIONS.reltol,
+        save_everystep = false,
+        saveat = ftype[]),
+        SOLVEROptions
+    )
+    _ss_condition = SteadyStateODECondition(similar(u0))
     cb = TerminateSteadyState(kwargs.abstol, kwargs.reltol, _ss_condition)
     kwargs2 =
         haskey(kwargs, :callback) ? merge(kwargs, (callback = CallbackSet(kwargs.callback, cb),)) :
@@ -101,16 +109,4 @@ function QuantumToolbox.steadystate(
     end
 
     return ADOs(Vector{ComplexF64}(sol.u[end]), M.dimensions, M.N, M.parity)
-end
-
-function _ss_condition(integrator, abstol, reltol, min_t)
-    # this condition is same as DiffEqBase.NormTerminationMode
-
-    du_dt = (integrator.u - integrator.uprev) / integrator.dt
-    norm_du_dt = norm(du_dt)
-    if (norm_du_dt <= reltol * norm(du_dt + integrator.u)) || (norm_du_dt <= abstol)
-        return true
-    else
-        return false
-    end
 end

--- a/test/HEOMSuperOp.jl
+++ b/test/HEOMSuperOp.jl
@@ -66,9 +66,9 @@
     trJρ = expect(J_me, ados_s)
     WTD_me = expect(J_me, ados_list) ./ trJρ
     for i in 1:length(tlist)
-        @test WTD_me[i] ≈ WTD_ans[i]
+        @test isapprox(WTD_me[i], WTD_ans[i]; atol = 1e-8)
     end
-    @test expect(J_me, ados_list[end]) / trJρ ≈ WTD_ans[end]
+    @test isapprox(expect(J_me, ados_list[end]) / trJρ, WTD_ans[end]; atol = 1e-8)
 
     ## Left lead with HEOM method and Right lead with local master equation
     bath = Fermion_Lorentz_Pade(d, Γ, μ, W, kT, N)


### PR DESCRIPTION
## Checklist
Thank you for contributing to `HierarchicalEOM.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
This PR optimizes the ODE callbacks to improve the efficiency of ODE solvers (`heomsolve` and `steadystate`).

Currently waiting for `QuantumToolbox v0.28` to be released.