### PR TITLE
Fix incorrect multithreading

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HierarchicalEOM"
 uuid = "a62dbcb7-80f5-4d31-9a88-8b19fd92b128"
 authors = ["Yi-Te Huang"]
-version = "2.4.5"
+version = "2.4.6"
 
 [deps]
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"

--- a/src/HierarchicalEOM.jl
+++ b/src/HierarchicalEOM.jl
@@ -31,7 +31,7 @@ import DiffEqCallbacks: FunctionCallingCallback, TerminateSteadyState
 import LinearSolve: LinearProblem, SciMLLinearSolveAlgorithm, UMFPACKFactorization
 
 # other dependencies (in alphabetical order)
-import Base.Threads: @threads, nthreads, Channel, threadid # TODO: remove threadid
+import Base.Threads: @threads, nthreads, Channel
 import FastExpm: fastExpm
 import JLD2: jldopen
 import Pkg

--- a/src/HierarchicalEOM.jl
+++ b/src/HierarchicalEOM.jl
@@ -31,7 +31,7 @@ import DiffEqCallbacks: FunctionCallingCallback, TerminateSteadyState
 import LinearSolve: LinearProblem, SciMLLinearSolveAlgorithm, UMFPACKFactorization
 
 # other dependencies (in alphabetical order)
-import Base.Threads: @threads, threadid, nthreads, lock, unlock, SpinLock
+import Base.Threads: @threads, nthreads, Channel, threadid # TODO: remove threadid
 import FastExpm: fastExpm
 import JLD2: jldopen
 import Pkg

--- a/src/heom_matrices/HierarchyDict.jl
+++ b/src/heom_matrices/HierarchyDict.jl
@@ -158,7 +158,7 @@ _gen_n_max(::Vector{AbstractFermionBath}, tier::Int, Nterm::Int) = (tier == 0) ?
                 end
             end
         end
-        drop_indices = reduce(vcat(drop_idx_list))
+        drop_indices = reduce(vcat, drop_idx_list)
         sort!(drop_indices)
         deleteat!(idx2nvec, drop_indices)
     end
@@ -247,7 +247,7 @@ end
                 end
             end
         end
-        drop_indices = reduce(vcat(drop_idx_list))
+        drop_indices = reduce(vcat, drop_idx_list)
         sort!(drop_indices)
         deleteat!(idx2nvec, drop_indices)
     end

--- a/src/heom_matrices/HierarchyDict.jl
+++ b/src/heom_matrices/HierarchyDict.jl
@@ -140,10 +140,10 @@ _gen_n_max(::Vector{AbstractFermionBath}, tier::Int, Nterm::Int) = (tier == 0) ?
     # create idx2nvec and remove nvec when its value of importance is below threshold
     idx2nvec = _Idx2Nvec(n_max, tier)
     if threshold > 0.0
-        N_thread = nthreads()
-        drop_idx_list = Vector{Int}[Int[] for i in 1:N_thread]
-        chnl = Channel{Vector{Int}}(N_thread)
-        foreach(i -> put!(chnl, drop_idx_list[i]), 1:N_thread)
+        Nthread = nthreads()
+        drop_idx_list = Vector{Int}[Int[] for i in 1:Nthread]
+        chnl = Channel{Vector{Int}}(Nthread)
+        foreach(i -> put!(chnl, drop_idx_list[i]), 1:Nthread)
 
         @threads for idx in eachindex(idx2nvec)
             nvec = idx2nvec[idx]
@@ -158,7 +158,7 @@ _gen_n_max(::Vector{AbstractFermionBath}, tier::Int, Nterm::Int) = (tier == 0) ?
                 end
             end
         end
-        drop_indices = vcat(drop_idx_list...)
+        drop_indices = reduce(vcat(drop_idx_list))
         sort!(drop_indices)
         deleteat!(idx2nvec, drop_indices)
     end
@@ -229,10 +229,10 @@ end
         end
     end
     if threshold > 0.0
-        N_thread = nthreads()
-        drop_idx_list = Vector{Int}[Int[] for i in 1:N_thread]
-        chnl = Channel{Vector{Int}}(N_thread)
-        foreach(i -> put!(chnl, drop_idx_list[i]), 1:N_thread)
+        Nthread = nthreads()
+        drop_idx_list = Vector{Int}[Int[] for i in 1:Nthread]
+        chnl = Channel{Vector{Int}}(Nthread)
+        foreach(i -> put!(chnl, drop_idx_list[i]), 1:Nthread)
 
         @threads for idx in eachindex(idx2nvec)
             nvec_b, nvec_f = idx2nvec[idx]
@@ -247,7 +247,7 @@ end
                 end
             end
         end
-        drop_indices = vcat(drop_idx_list...)
+        drop_indices = reduce(vcat(drop_idx_list))
         sort!(drop_indices)
         deleteat!(idx2nvec, drop_indices)
     end

--- a/src/heom_matrices/M_Boson.jl
+++ b/src/heom_matrices/M_Boson.jl
@@ -90,14 +90,14 @@ Note that the parity only need to be set as `ODD` when the system contains fermi
     L_row = [Int[] for _ in 1:Nthread]
     L_col = [Int[] for _ in 1:Nthread]
     L_val = [ComplexF64[] for _ in 1:Nthread]
-
+    chnl = Channel{Tuple{Vector{Int},Vector{Int},Vector{ComplexF64}}}(Nthread)
+    foreach(i -> put!(chnl, (L_row[i], L_col[i], L_val[i])), 1:Nthread)
     if verbose
         println("Preparing block matrices for HEOM Liouvillian superoperator (using $(Nthread) threads)...")
         flush(stdout)
         prog = ProgressBar(Nado)
     end
     @threads for idx in 1:Nado
-        tID = threadid()
 
         # boson (current level) superoperator
         nvec = idx2nvec[idx]
@@ -107,7 +107,9 @@ Note that the parity only need to be set as `ODD` when the system contains fermi
         else
             op = Lsys
         end
-        add_operator!(op, L_row[tID], L_col[tID], L_val[tID], Nado, idx, idx)
+        L_tuple = take!(chnl)
+        add_operator!(op, L_tuple[1], L_tuple[2], L_tuple[3], Nado, idx, idx)
+        put!(chnl, L_tuple)
 
         # connect to bosonic (n+1)th- & (n-1)th- level superoperator
         mode = 0
@@ -123,7 +125,9 @@ Note that the parity only need to be set as `ODD` when the system contains fermi
                     if (threshold == 0.0) || haskey(nvec2idx, nvec_neigh)
                         idx_neigh = nvec2idx[nvec_neigh]
                         op = minus_i_D_op(bB, k, n_k)
-                        add_operator!(op, L_row[tID], L_col[tID], L_val[tID], Nado, idx, idx_neigh)
+                        L_tuple = take!(chnl)
+                        add_operator!(op, L_tuple[1], L_tuple[2], L_tuple[3], Nado, idx, idx_neigh)
+                        put!(chnl, L_tuple)
                     end
                     Nvec_plus!(nvec_neigh, mode)
                 end
@@ -134,7 +138,9 @@ Note that the parity only need to be set as `ODD` when the system contains fermi
                     if (threshold == 0.0) || haskey(nvec2idx, nvec_neigh)
                         idx_neigh = nvec2idx[nvec_neigh]
                         op = minus_i_B_op(bB)
-                        add_operator!(op, L_row[tID], L_col[tID], L_val[tID], Nado, idx, idx_neigh)
+                        L_tuple = take!(chnl)
+                        add_operator!(op, L_tuple[1], L_tuple[2], L_tuple[3], Nado, idx, idx_neigh)
+                        put!(chnl, L_tuple)
                     end
                     Nvec_minus!(nvec_neigh, mode)
                 end


### PR DESCRIPTION
## Checklist
Thank you for contributing to `HierarchicalEOM.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
This PR tries to fix the incorrect usage of multithreading:
- [x] Multithreading in generating `HierarchyDict`
- [x] Multothreading in contructing `HEOMLS`

## Related issues or PRs
fix #150