### PR TITLE
Enhanced `cu` function with double precision support

### DIFF
--- a/ext/HierarchicalEOM_CUDAExt.jl
+++ b/ext/HierarchicalEOM_CUDAExt.jl
@@ -2,7 +2,7 @@ module HierarchicalEOM_CUDAExt
 
 using HierarchicalEOM
 import HierarchicalEOM: _HandleVectorType, _HandleTraceVectorType
-import QuantumToolbox: _CType
+import QuantumToolbox: _CType, _convert_eltype_wordsize
 import CUDA
 import CUDA: cu, CuArray
 import CUDA.CUSPARSE: CuSparseVector, CuSparseMatrixCSC
@@ -10,22 +10,33 @@ import SparseArrays: sparse, SparseVector, SparseMatrixCSC
 import SciMLOperators: MatrixOperator, ScaledOperator, AddedOperator
 
 @doc raw"""
-    cu(M::AbstractHEOMLSMatrix)
+    cu(M::AbstractHEOMLSMatrix, word_size::Union{Val,Int} = Val(64))
 Return a new HEOMLS-matrix-type object with `M.data` is in the type of `CuSparseMatrixCSC{ComplexF32, Int32}` for gpu calculations.
+
+# Arguments
+- `M::AbstractHEOMLSMatrix` : the matrix given from HEOM model
+- `word_size::Union{Val,Int}` : The word size of the element type of `M`, can be either `32` or `64`. Default to `64`.
 """
-cu(M::AbstractHEOMLSMatrix) = CuSparseMatrixCSC(M)
+function cu(M::AbstractHEOMLSMatrix; word_size::Union{Val,Int} = Val(64))
+    _word_size = getVal(makeVal(word_size))
+
+    ((_word_size == 64) || (_word_size == 32)) || throw(DomainError(_word_size, "The word size should be 32 or 64."))
+
+    return CuSparseMatrixCSC{_convert_eltype_wordsize(eltype(M), word_size)}(M)
+end
 
 @doc raw"""
-    CuSparseMatrixCSC(M::AbstractHEOMLSMatrix)
-Return a new HEOMLS-matrix-type object with `M.data` is in the type of `CuSparseMatrixCSC{ComplexF32, Int32}` for gpu calculations.
+    CuSparseMatrixCSC{T}(M::AbstractHEOMLSMatrix)
+
+Return a new HEOMLS-matrix-type object with `M.data` is in the type of `CUDA.CUSPARSE.CuSparseMatrixCSC` with element type `T` for gpu calculations.
 """
-function CuSparseMatrixCSC(M::T) where {T<:AbstractHEOMLSMatrix}
-    A_gpu = _convert_to_gpu_matrix(M.data)
-    if T <: M_S
+function CuSparseMatrixCSC{T}(M::MT) where {T, MT<:AbstractHEOMLSMatrix}
+    A_gpu = _convert_to_gpu_matrix(M.data, T)
+    if MT <: M_S
         return M_S(A_gpu, M.tier, M.dimensions, M.N, M.sup_dim, M.parity)
-    elseif T <: M_Boson
+    elseif MT <: M_Boson
         return M_Boson(A_gpu, M.tier, M.dimensions, M.N, M.sup_dim, M.parity, M.bath, M.hierarchy)
-    elseif T <: M_Fermion
+    elseif MT <: M_Fermion
         return M_Fermion(A_gpu, M.tier, M.dimensions, M.N, M.sup_dim, M.parity, M.bath, M.hierarchy)
     else
         return M_Boson_Fermion(
@@ -43,26 +54,26 @@ function CuSparseMatrixCSC(M::T) where {T<:AbstractHEOMLSMatrix}
     end
 end
 
-CuSparseMatrixCSC{ComplexF32}(M::HEOMSuperOp) = HEOMSuperOp(_convert_to_gpu_matrix(M.data), M.dimensions, M.N, M.parity)
+CuSparseMatrixCSC{T}(M::HEOMSuperOp) where {T} = HEOMSuperOp(_convert_to_gpu_matrix(M.data, T), M.dimensions, M.N, M.parity)
 
-function _convert_to_gpu_matrix(A::AbstractSparseMatrix)
-    if A isa CuSparseMatrixCSC{ComplexF32,Int32}
+function _convert_to_gpu_matrix(A::AbstractSparseMatrix, ElType::Type{T}) where {T<:Number}
+    if A isa CuSparseMatrixCSC{ElType,Int32}
         return A
     elseif A isa CuSparseMatrixCSC
         colptr = CuArray{Int32}(A.colPtr)
         rowval = CuArray{Int32}(A.rowVal)
-        nzval = CuArray{ComplexF32}(A.nzVal)
-        return CuSparseMatrixCSC{ComplexF32,Int32}(colptr, rowval, nzval, size(A))
+        nzval = CuArray{ElType}(A.nzVal)
+        return CuSparseMatrixCSC{ElType,Int32}(colptr, rowval, nzval, size(A))
     else
         colptr = CuArray{Int32}(A.colptr)
         rowval = CuArray{Int32}(A.rowval)
-        nzval = CuArray{ComplexF32}(A.nzval)
-        return CuSparseMatrixCSC{ComplexF32,Int32}(colptr, rowval, nzval, size(A))
+        nzval = CuArray{ElType}(A.nzval)
+        return CuSparseMatrixCSC{ElType,Int32}(colptr, rowval, nzval, size(A))
     end
 end
-_convert_to_gpu_matrix(A::MatrixOperator) = MatrixOperator(_convert_to_gpu_matrix(A.A))
-_convert_to_gpu_matrix(A::ScaledOperator) = ScaledOperator(A.λ, _convert_to_gpu_matrix(A.L))
-_convert_to_gpu_matrix(A::AddedOperator) = AddedOperator(map(op -> _convert_to_gpu_matrix(op), A.ops))
+_convert_to_gpu_matrix(A::MatrixOperator, ElType) = MatrixOperator(_convert_to_gpu_matrix(A.A, ElType))
+_convert_to_gpu_matrix(A::ScaledOperator, ElType) = ScaledOperator(A.λ, _convert_to_gpu_matrix(A.L, ElType))
+_convert_to_gpu_matrix(A::AddedOperator, ElType) = AddedOperator(map(op -> _convert_to_gpu_matrix(op, ElType), A.ops))
 
 # change the type of `ADOs` to match the type of HEOMLS matrix
 _HandleVectorType(M::Type{<:CuSparseMatrixCSC}, V::SparseVector) = CuArray{_CType(eltype(M))}(V)

--- a/ext/HierarchicalEOM_CUDAExt.jl
+++ b/ext/HierarchicalEOM_CUDAExt.jl
@@ -18,11 +18,12 @@ Return a new HEOMLS-matrix-type object with `M.data` is in the type of `CuSparse
 - `word_size::Union{Val,Int}` : The word size of the element type of `M`, can be either `32` or `64`. Default to `64`.
 """
 function cu(M::AbstractHEOMLSMatrix; word_size::Union{Val,Int} = Val(64))
-    _word_size = getVal(makeVal(word_size))
+    word_size_val = makeVal(word_size)
+    _word_size = getVal(word_size_val)
 
     ((_word_size == 64) || (_word_size == 32)) || throw(DomainError(_word_size, "The word size should be 32 or 64."))
 
-    return CuSparseMatrixCSC{_convert_eltype_wordsize(eltype(M), word_size)}(M)
+    return CuSparseMatrixCSC{_convert_eltype_wordsize(eltype(M), word_size_val)}(M)
 end
 
 @doc raw"""

--- a/ext/HierarchicalEOM_CUDAExt.jl
+++ b/ext/HierarchicalEOM_CUDAExt.jl
@@ -10,7 +10,7 @@ import SparseArrays: sparse, SparseVector, SparseMatrixCSC
 import SciMLOperators: MatrixOperator, ScaledOperator, AddedOperator
 
 @doc raw"""
-    cu(M::AbstractHEOMLSMatrix, word_size::Union{Val,Int} = Val(64))
+    cu(M::AbstractHEOMLSMatrix; word_size::Union{Val,Int} = Val(64))
 Return a new HEOMLS-matrix-type object with `M.data` is in the type of `CuSparseMatrixCSC{ComplexF32, Int32}` for gpu calculations.
 
 # Arguments

--- a/ext/HierarchicalEOM_CUDAExt.jl
+++ b/ext/HierarchicalEOM_CUDAExt.jl
@@ -30,7 +30,7 @@ end
 
 Return a new HEOMLS-matrix-type object with `M.data` is in the type of `CUDA.CUSPARSE.CuSparseMatrixCSC` with element type `T` for gpu calculations.
 """
-function CuSparseMatrixCSC{T}(M::MT) where {T, MT<:AbstractHEOMLSMatrix}
+function CuSparseMatrixCSC{T}(M::MT) where {T,MT<:AbstractHEOMLSMatrix}
     A_gpu = _convert_to_gpu_matrix(M.data, T)
     if MT <: M_S
         return M_S(A_gpu, M.tier, M.dimensions, M.N, M.sup_dim, M.parity)
@@ -54,7 +54,8 @@ function CuSparseMatrixCSC{T}(M::MT) where {T, MT<:AbstractHEOMLSMatrix}
     end
 end
 
-CuSparseMatrixCSC{T}(M::HEOMSuperOp) where {T} = HEOMSuperOp(_convert_to_gpu_matrix(M.data, T), M.dimensions, M.N, M.parity)
+CuSparseMatrixCSC{T}(M::HEOMSuperOp) where {T} =
+    HEOMSuperOp(_convert_to_gpu_matrix(M.data, T), M.dimensions, M.N, M.parity)
 
 function _convert_to_gpu_matrix(A::AbstractSparseMatrix, ElType::Type{T}) where {T<:Number}
     if A isa CuSparseMatrixCSC{ElType,Int32}

--- a/ext/HierarchicalEOM_CUDAExt.jl
+++ b/ext/HierarchicalEOM_CUDAExt.jl
@@ -2,7 +2,7 @@ module HierarchicalEOM_CUDAExt
 
 using HierarchicalEOM
 import HierarchicalEOM: _HandleVectorType, _HandleTraceVectorType
-import QuantumToolbox: _CType, _convert_eltype_wordsize
+import QuantumToolbox: _CType, _convert_eltype_wordsize, makeVal, getVal
 import CUDA
 import CUDA: cu, CuArray
 import CUDA.CUSPARSE: CuSparseVector, CuSparseMatrixCSC

--- a/test/gpu/CUDAExt.jl
+++ b/test/gpu/CUDAExt.jl
@@ -30,6 +30,7 @@ CUDA.@time @testset "CUDA Extension" begin
     L_gpu = cu(L_cpu)
     sol_cpu = heomsolve(L_cpu, ψ0, [0, 10]; e_ops = e_ops, verbose = false)
     sol_gpu = heomsolve(L_gpu, ψ0, [0, 10]; e_ops = e_ops, verbose = false)
+    @test L_gpu.data.A isa CUDA.CUSPARSE.CuSparseMatrixCSC{ComplexF64, Int32}
     @test all(isapprox.(sol_cpu.expect[1, :], sol_gpu.expect[1, :], atol = 1e-4))
     @test isapprox(getRho(sol_cpu.ados[end]), getRho(sol_gpu.ados[end]), atol = 1e-4)
 
@@ -38,6 +39,7 @@ CUDA.@time @testset "CUDA Extension" begin
     L_gpu = cu(L_cpu)
     sol_cpu = heomsolve(L_cpu, ψ0, [0, 10]; e_ops = e_ops, verbose = false)
     sol_gpu = heomsolve(L_gpu, ψ0, [0, 10]; e_ops = e_ops, verbose = false)
+    @test L_gpu.data.A isa CUDA.CUSPARSE.CuSparseMatrixCSC{ComplexF64, Int32}
     @test all(isapprox.(sol_cpu.expect[1, :], sol_gpu.expect[1, :], atol = 1e-4))
     @test isapprox(getRho(sol_cpu.ados[end]), getRho(sol_gpu.ados[end]), atol = 1e-4)
 
@@ -46,6 +48,7 @@ CUDA.@time @testset "CUDA Extension" begin
     L_gpu = cu(L_cpu)
     sol_cpu = heomsolve(L_cpu, ψ0, [0, 10]; e_ops = e_ops, verbose = false)
     sol_gpu = heomsolve(L_gpu, ψ0, [0, 10]; e_ops = e_ops, verbose = false)
+    @test L_gpu.data.A isa CUDA.CUSPARSE.CuSparseMatrixCSC{ComplexF64, Int32}
     @test all(isapprox.(sol_cpu.expect[1, :], sol_gpu.expect[1, :], atol = 1e-4))
     @test isapprox(getRho(sol_cpu.ados[end]), getRho(sol_gpu.ados[end]), atol = 1e-4)
 
@@ -55,6 +58,7 @@ CUDA.@time @testset "CUDA Extension" begin
     tlist = 0:1:10
     sol_cpu = heomsolve(L_cpu, ψ0, tlist; e_ops = e_ops, saveat = tlist, verbose = false)
     sol_gpu = heomsolve(L_gpu, ψ0, tlist; e_ops = e_ops, saveat = tlist, verbose = false)
+    @test L_gpu.data.A isa CUDA.CUSPARSE.CuSparseMatrixCSC{ComplexF64, Int32}
     @test all(isapprox.(sol_cpu.expect[1, :], sol_gpu.expect[1, :], atol = 1e-4))
     for i in 1:length(tlist)
         @test isapprox(getRho(sol_cpu.ados[i]), getRho(sol_gpu.ados[i]), atol = 1e-4)
@@ -85,12 +89,13 @@ CUDA.@time @testset "CUDA Extension" begin
     L_even_gpu = cu(L_even_cpu)
     ados_cpu = steadystate(L_even_cpu; verbose = false)
     ados_gpu = steadystate(L_even_gpu, ψ0, 10; verbose = false)
+    @test L_even_gpu.data.A isa CUDA.CUSPARSE.CuSparseMatrixCSC{ComplexF64, Int32}
     @test all(isapprox.(ados_cpu.data, ados_gpu.data; atol = 1e-6))
 
     ## solve density of states
     ωlist = -5:0.5:5
     L_odd_cpu = M_Fermion(Hsys, tier, bath_list, ODD; verbose = false)
-    L_odd_gpu = cu(L_odd_cpu)
+    L_odd_gpu = cu(L_odd_cpu, word_size = 32)
     dos_cpu = DensityOfStates(L_odd_cpu, ados_cpu, d_up, ωlist; verbose = false)
     dos_gpu = DensityOfStates(
         L_odd_gpu,
@@ -100,6 +105,7 @@ CUDA.@time @testset "CUDA Extension" begin
         solver = KrylovJL_BICGSTAB(rtol = 1.0f-10, atol = 1.0f-12),
         verbose = false,
     )
+    @test L_odd_gpu.data.A isa CUDA.CUSPARSE.CuSparseMatrixCSC{ComplexF32, Int32}
     for (i, ω) in enumerate(ωlist)
         @test dos_cpu[i] ≈ dos_gpu[i] atol = 1e-6
     end

--- a/test/gpu/CUDAExt.jl
+++ b/test/gpu/CUDAExt.jl
@@ -30,7 +30,7 @@ CUDA.@time @testset "CUDA Extension" begin
     L_gpu = cu(L_cpu)
     sol_cpu = heomsolve(L_cpu, ψ0, [0, 10]; e_ops = e_ops, verbose = false)
     sol_gpu = heomsolve(L_gpu, ψ0, [0, 10]; e_ops = e_ops, verbose = false)
-    @test L_gpu.data.A isa CUDA.CUSPARSE.CuSparseMatrixCSC{ComplexF64, Int32}
+    @test L_gpu.data.A isa CUDA.CUSPARSE.CuSparseMatrixCSC{ComplexF64,Int32}
     @test all(isapprox.(sol_cpu.expect[1, :], sol_gpu.expect[1, :], atol = 1e-4))
     @test isapprox(getRho(sol_cpu.ados[end]), getRho(sol_gpu.ados[end]), atol = 1e-4)
 
@@ -39,7 +39,7 @@ CUDA.@time @testset "CUDA Extension" begin
     L_gpu = cu(L_cpu)
     sol_cpu = heomsolve(L_cpu, ψ0, [0, 10]; e_ops = e_ops, verbose = false)
     sol_gpu = heomsolve(L_gpu, ψ0, [0, 10]; e_ops = e_ops, verbose = false)
-    @test L_gpu.data.A isa CUDA.CUSPARSE.CuSparseMatrixCSC{ComplexF64, Int32}
+    @test L_gpu.data.A isa CUDA.CUSPARSE.CuSparseMatrixCSC{ComplexF64,Int32}
     @test all(isapprox.(sol_cpu.expect[1, :], sol_gpu.expect[1, :], atol = 1e-4))
     @test isapprox(getRho(sol_cpu.ados[end]), getRho(sol_gpu.ados[end]), atol = 1e-4)
 
@@ -48,7 +48,7 @@ CUDA.@time @testset "CUDA Extension" begin
     L_gpu = cu(L_cpu)
     sol_cpu = heomsolve(L_cpu, ψ0, [0, 10]; e_ops = e_ops, verbose = false)
     sol_gpu = heomsolve(L_gpu, ψ0, [0, 10]; e_ops = e_ops, verbose = false)
-    @test L_gpu.data.A isa CUDA.CUSPARSE.CuSparseMatrixCSC{ComplexF64, Int32}
+    @test L_gpu.data.A isa CUDA.CUSPARSE.CuSparseMatrixCSC{ComplexF64,Int32}
     @test all(isapprox.(sol_cpu.expect[1, :], sol_gpu.expect[1, :], atol = 1e-4))
     @test isapprox(getRho(sol_cpu.ados[end]), getRho(sol_gpu.ados[end]), atol = 1e-4)
 
@@ -58,7 +58,7 @@ CUDA.@time @testset "CUDA Extension" begin
     tlist = 0:1:10
     sol_cpu = heomsolve(L_cpu, ψ0, tlist; e_ops = e_ops, saveat = tlist, verbose = false)
     sol_gpu = heomsolve(L_gpu, ψ0, tlist; e_ops = e_ops, saveat = tlist, verbose = false)
-    @test L_gpu.data.A isa CUDA.CUSPARSE.CuSparseMatrixCSC{ComplexF64, Int32}
+    @test L_gpu.data.A isa CUDA.CUSPARSE.CuSparseMatrixCSC{ComplexF64,Int32}
     @test all(isapprox.(sol_cpu.expect[1, :], sol_gpu.expect[1, :], atol = 1e-4))
     for i in 1:length(tlist)
         @test isapprox(getRho(sol_cpu.ados[i]), getRho(sol_gpu.ados[i]), atol = 1e-4)
@@ -89,7 +89,7 @@ CUDA.@time @testset "CUDA Extension" begin
     L_even_gpu = cu(L_even_cpu)
     ados_cpu = steadystate(L_even_cpu; verbose = false)
     ados_gpu = steadystate(L_even_gpu, ψ0, 10; verbose = false)
-    @test L_even_gpu.data.A isa CUDA.CUSPARSE.CuSparseMatrixCSC{ComplexF64, Int32}
+    @test L_even_gpu.data.A isa CUDA.CUSPARSE.CuSparseMatrixCSC{ComplexF64,Int32}
     @test all(isapprox.(ados_cpu.data, ados_gpu.data; atol = 1e-6))
 
     ## solve density of states
@@ -105,7 +105,7 @@ CUDA.@time @testset "CUDA Extension" begin
         solver = KrylovJL_BICGSTAB(rtol = 1.0f-10, atol = 1.0f-12),
         verbose = false,
     )
-    @test L_odd_gpu.data.A isa CUDA.CUSPARSE.CuSparseMatrixCSC{ComplexF32, Int32}
+    @test L_odd_gpu.data.A isa CUDA.CUSPARSE.CuSparseMatrixCSC{ComplexF32,Int32}
     for (i, ω) in enumerate(ωlist)
         @test dos_cpu[i] ≈ dos_gpu[i] atol = 1e-6
     end


### PR DESCRIPTION
## Checklist
Thank you for contributing to `HierarchicalEOM.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
Add optional `word_size` argument, either `Val(64)` for double precision (default) or `Val(32)` for single precision.